### PR TITLE
quick fix of demo memory consumption

### DIFF
--- a/accessory/demos/multi_turn.py
+++ b/accessory/demos/multi_turn.py
@@ -50,12 +50,17 @@ def model_worker(
     # set the print behavior.
     setup_for_distributed(rank == 0)
 
-    torch.set_default_tensor_type(torch.cuda.HalfTensor)
     model = MetaModel(
         args.llama_type, args.llama_config, args.tokenizer_path,
         with_visual=False, max_seq_len=args.model_max_seq_len,
     )
-    torch.set_default_tensor_type(torch.FloatTensor)
+    target_dtype = {
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+    }[args.dtype]
+    for n, p in model.named_parameters():
+        p.data = p.data.to(target_dtype)
+    model.cuda().eval()
     print(f"Loading pretrained weights from {args.pretrained_path}")
     load_pretrained(args.pretrained_path, args.pretrained_type, model)
     print(f"Model = {str(model)}")
@@ -178,6 +183,8 @@ if __name__ == "__main__":
                         help="A port used by the PyTorch distributed module to initialize.")
     parser.add_argument("--master_addr", type=str, default="127.0.0.1",
                         help="An address used by the PyTorch distributed module to initialize.")
+    parser.add_argument("--dtype", type=str, choices=["fp16", "bf16"], default="bf16",
+                        help="The dtype used for model weights and inference.")
     args = parser.parse_args()
 
     # check and setup gpu_ids to use


### PR DESCRIPTION
We probably need this quick fix because the demo memory issue is more serious than I initially thought: The memory consumption turns out to be 3x (instead of 2x as mentioned in #4). As a result, it would require a 8*A100/H100 80GB machine to run the 70b demo, which becomes a rather severe limitation.

This PR applies an imperfect yet quick fix: It now creates the model on CPU first, convert it to fp16/bf16, then move the model to GPU. The fix is primarily targeted for minimal side effect so that it can be landed ASAP: Only the demo itself is changed. The downside is higher host memory consumption and slower startup speed, but it now runs on machines with much less GPU memory (e.g., 8x3090 24GB).

I'm planning for a refactor of the tensor dtype/device management part which will resolve the issue in a more elegant way, but it will probably take more time and need some thorough testing to avoid breaking the existing functionalities.