### PR TITLE
change dataset config in yaml files to dictionary format

### DIFF
--- a/accessory/configs/data/finetune/mm/alpaca_llava.yaml
+++ b/accessory/configs/data/finetune/mm/alpaca_llava.yaml
@@ -1,3 +1,7 @@
 META:
-  - ['../data/alpaca_gpt4_data.json', 'text']
-  - ['../data/llava_instruct_150k_single_turn.json', 'image_text']
+  -
+    path: '../data/alpaca_gpt4_data.json'
+    type: 'text'
+  -
+    path: '../data/llava_instruct_150k_single_turn.json'
+    type: 'image_text'

--- a/accessory/configs/data/finetune/sg/alpaca.yaml
+++ b/accessory/configs/data/finetune/sg/alpaca.yaml
@@ -1,2 +1,4 @@
 META:
-  - ['../data/alpaca_gpt4_data.json', 'text']
+  -
+    path: '../data/alpaca_gpt4_data.json'
+    type: 'text'

--- a/accessory/configs/data/finetune/sg/dialog_flacuna.yaml
+++ b/accessory/configs/data/finetune/sg/dialog_flacuna.yaml
@@ -1,2 +1,4 @@
 META:
-  - ['../data/flan_mini_fastchat_4k.json', 'text']
+  -
+    path: '../data/flan_mini_fastchat_4k.json'
+    type: 'text'

--- a/accessory/configs/data/finetune/sg/dialog_lima.yaml
+++ b/accessory/configs/data/finetune/sg/dialog_lima.yaml
@@ -1,2 +1,4 @@
 META:
-  - ['../data/lima_vicuna_format.json', 'text']
+  -
+    path: '../data/lima_vicuna_format.json'
+    type: 'text'

--- a/accessory/configs/data/finetune/sg/dialog_moss.yaml
+++ b/accessory/configs/data/finetune/sg/dialog_moss.yaml
@@ -1,2 +1,4 @@
 META:
-  - ['../data/moss_fastchat_4k.json', 'text']
+  -
+    path: '../data/moss_fastchat_4k.json'
+    type: 'text'

--- a/accessory/configs/data/finetune/sg/dialog_sharegpt.yaml
+++ b/accessory/configs/data/finetune/sg/dialog_sharegpt.yaml
@@ -1,2 +1,4 @@
 META:
-  - ['../data/sharegpt.json', 'text']
+  -
+    path: '../data/sharegpt.json'
+    type: 'text'

--- a/accessory/configs/data/finetune/sg/dialog_ultrachat.yaml
+++ b/accessory/configs/data/finetune/sg/dialog_ultrachat.yaml
@@ -1,2 +1,4 @@
 META:
-  - ['../data/ultrachat_fastchat_4k.json', 'text']
+  -
+    path: '../data/ultrachat_fastchat_4k.json'
+    type: 'text'

--- a/accessory/configs/data/finetune/sg/gorilla.yaml
+++ b/accessory/configs/data/finetune/sg/gorilla.yaml
@@ -1,2 +1,4 @@
 META:
-  - ['../data/tensorflow_train_formatted.json', 'text']
+  -
+    path: '../data/tensorflow_train_formatted.json'
+    type: 'text'

--- a/accessory/configs/data/finetune/sg/platypus.yaml
+++ b/accessory/configs/data/finetune/sg/platypus.yaml
@@ -1,2 +1,7 @@
 META:
-  - ['../data/Platypus_alpaca_format.json', 'text']
+  -
+    path: '../data/Platypus_alpaca_format.json'
+    type: 'text'
+  -
+    path: '../data/alpaca_gpt4_data.json'
+    type: 'text'

--- a/accessory/data/conversation/dataset.py
+++ b/accessory/data/conversation/dataset.py
@@ -98,7 +98,8 @@ class FinetuneDialogDataset(Dataset):
         print("DATASET CONFIG:")
         print(self.config)
         group_ann = {}
-        for meta_path, meta_type in self.config['META']:
+        for meta in self.config['META']:
+            meta_path, meta_type = meta['path'], meta['type']
             meta_l = json.load(open(meta_path))
             if meta_type not in group_ann:
                 group_ann[meta_type] = []

--- a/accessory/data/system_prompt.py
+++ b/accessory/data/system_prompt.py
@@ -1,0 +1,32 @@
+first = [True]
+
+def format_prompt(instruction, input=None, sys_name="alpaca"):
+    if input is None or input == "" or input.isspace():
+        input = None
+    if sys_name == "alpaca":
+        PROMPT_DICT = {
+            "prompt_input": (
+                "Below is an instruction that describes a task, paired with an input that provides further context. "
+                "Write a response that appropriately completes the request.\n\n"
+                "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:"
+            ),
+            "prompt_no_input": (
+                "Below is an instruction that describes a task. "
+                "Write a response that appropriately completes the request.\n\n"
+                "### Instruction:\n{instruction}\n\n### Response:"
+            ),
+        }
+        if input is None or input=='':
+            return PROMPT_DICT['prompt_no_input'].format_map({'instruction': instruction})
+        else:
+            return PROMPT_DICT["prompt_input"].format_map({'instruction': instruction, 'input': input})
+
+    elif sys_name == "qg":  # question_generation
+        prompt = (
+            "Generate a question whose answer is:\n{instruction}\n\n"
+            "Question:\n"
+        )
+        if first[0]:
+            print(prompt.format_map({'instruction': instruction}))
+            first[0] = False
+        return prompt.format_map({'instruction': instruction})

--- a/accessory/main_finetune.py
+++ b/accessory/main_finetune.py
@@ -39,7 +39,6 @@ from torch.utils.data import Dataset
 from data.alpaca import FinetuneDataset, transform_train, FinetuneDistSampler
 from data.conversation.dataset import FinetuneDialogDataset
 
-from util.quant import quantize
 from util.tensor_parallel import load_tensor_parallel_model
 
 
@@ -165,6 +164,7 @@ def main(args):
     print("Start initialization.")
 
     if args.quant:
+        from util.quant import quantize
         from transformers.utils.quantization_config import BitsAndBytesConfig
         for i in range(misc.get_world_size()):
             if i == misc.get_rank():

--- a/accessory/main_pretrain.py
+++ b/accessory/main_pretrain.py
@@ -47,7 +47,7 @@ def get_args_parser():
                         help='Accumulate gradient iterations (for increasing the effective batch size under memory constraints)')
 
     # Model parameters
-    parser.add_argument('--llama_type', default='llama', type=str, metavar='MODEL', choices=['llama',],
+    parser.add_argument('--llama_type', default='llama', type=str, metavar='MODEL',
                         help='Name of model to train')
     parser.add_argument('--llama_config', default=['params.json'], nargs="+",
                         help='Path to llama model config')


### PR DESCRIPTION
We plan to support more options for more flexible dataset configuration, e.g. defining which prompt template to use. However, the current tuple-based config style can no longer support this requirement. Therefore we refactor the configuration format, and now a dictionary is used to configure a dataset. 