### PR TITLE
Support lazy model init

### DIFF
--- a/accessory/model/layers/__init__.py
+++ b/accessory/model/layers/__init__.py
@@ -1,0 +1,7 @@
+from .linear import Linear
+from .tensor_parallel import (
+    ColumnParallelLinear, RowParallelLinear, ParallelEmbedding,
+)
+
+__all__ = ["Linear", "ColumnParallelLinear", "RowParallelLinear",
+           "ParallelEmbedding"]

--- a/accessory/model/layers/linear.py
+++ b/accessory/model/layers/linear.py
@@ -1,0 +1,91 @@
+import functools
+import math
+from typing import Any, Callable, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def get_default_linear_weight_init_fn():
+    return functools.partial(nn.init.kaiming_uniform_, a=math.sqrt(5))
+
+
+def get_default_linear_bias_init_fn(fan_in):
+    bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+    return functools.partial(nn.init.uniform_, a=-bound, b=bound)
+
+
+class Linear(nn.Module):
+    r"""A Linear module mostly compatible with the PyTorch v2.0.1 builtin one,
+    with additional initializer args ``*_init_method``. This is to support
+    deferred custom weight initialization: We expect that parameters are
+    materialized and set by calling ``Module.reset_parameters()`` in deferred
+    initialization, but the ``reset_parameters`` of the builtin ``Linear``
+    layer always uses default initialization, making custom initialization
+    (e.g., ``xavier_uniform`` or zero initialization) impossible. We
+    reimplement a Linear module whose ``reset_parameter`` method respects the
+    initializers passed in by the user.
+
+    Args:
+        in_features (int): Input feature dimension.
+        out_features (int): Output feature dimension.
+        bias (bool): Whether a learnable bias is added. Default is ``False``.
+        weight_init_fn (Callable[[torch.Tensor], Any], optional): Initializer
+            function of the ``weight`` parameter. If not set, follows the
+            default initialization of the builtin ``nn.Linear``.
+        bias_init_fn (Callable[[torch.Tensor], Any], optional): Initializer
+            function of the ``bias`` parameter. If not set, follows the default
+            initialization of the builtin ``nn.Linear``.
+        device: The device to be passed into the factory function when creating
+            the parameter tensors.
+        dtype: The dtype to be passed into the factory function when creating
+            the parameter tensors.
+    """
+
+    def __init__(
+        self, in_features: int, out_features: int, bias: bool = True,
+        weight_init_fn: Optional[Callable[[torch.Tensor], Any]] = None,
+        bias_init_fn: Optional[Callable[[torch.Tensor], Any]] = None,
+        device=None, dtype=None,
+    ) -> None:
+        super().__init__()
+
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight_init_fn = weight_init_fn
+        self.bias_init_fn = bias_init_fn
+
+        self.weight = nn.Parameter(
+            torch.empty([out_features, in_features], **factory_kwargs)
+        )
+        if bias:
+            self.bias = nn.Parameter(
+                torch.empty([out_features], **factory_kwargs)
+            )
+        else:
+            self.register_parameter("bias", None)
+
+        self.reset_parametes()
+
+    def reset_parametes(self) -> None:
+        if not self.weight.is_meta:
+            weight_init_fn = (
+                self.weight_init_fn or get_default_linear_weight_init_fn()
+            )
+            weight_init_fn(self.weight.data)
+        if self.bias is not None and not self.bias.is_meta:
+            bias_init_fn = (
+                self.bias_init_fn
+                or get_default_linear_bias_init_fn(self.in_features)
+            )
+            bias_init_fn(self.bias.data)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return F.linear(input, self.weight, self.bias)
+
+    def extra_repr(self) -> str:
+        return "in_features={}, out_features={}, bias={}".format(
+            self.in_features, self.out_features, self.bias is not None
+        )

--- a/accessory/model/layers/tensor_parallel/__init__.py
+++ b/accessory/model/layers/tensor_parallel/__init__.py
@@ -1,0 +1,4 @@
+from .linear import ColumnParallelLinear, RowParallelLinear
+from .embedding import ParallelEmbedding
+
+__all__ = ["ColumnParallelLinear", "RowParallelLinear", "ParallelEmbedding"]

--- a/accessory/model/layers/tensor_parallel/embedding.py
+++ b/accessory/model/layers/tensor_parallel/embedding.py
@@ -1,0 +1,128 @@
+from typing import Any, Callable, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from fairscale.nn.model_parallel.initialize import (
+    get_model_parallel_world_size,
+)
+from fairscale.nn.model_parallel.mappings import (
+    copy_to_model_parallel_region,
+    gather_from_model_parallel_region,
+)
+from .utils import init_tensor_parallel_weights
+
+
+class ParallelEmbedding(nn.Module):
+    r"""A tensor-parallel embedding layer. The output feature dimensions are
+    divided among the tensor parallel ranks. Each part of the embeddings is
+    calculated separately on each rank and gathered to form the complete
+    embeddings.
+
+    Args:
+        num_embeddings (int): size of the dictionary of embeddings
+        embedding_dim (int): the size of each embedding vector
+        padding_idx (int, optional): If specified, the entries at
+            :attr:`padding_idx` do not contribute to the gradient; therefore,
+            the embedding vector at :attr:`padding_idx` is not updated during
+            training, i.e. it remains as a fixed "pad". For a newly
+            constructed Embedding, the embedding vector at :attr:`padding_idx`
+            will default to all zeros, but can be updated to another value to
+            be used as the padding vector.
+        scale_grad_by_freq (bool, optional): If given, this will scale
+            gradients by the inverse of frequency of the words in the
+            mini-batch. Default ``False``.
+        sparse (bool, optional): If ``True``, gradient w.r.t. :attr:`weight`
+            matrix will be a sparse tensor. See Notes for more details
+            regarding sparse gradients.
+        init_fn (Callable[[torch.Tensor], Any], optional): Initializer function
+            of the ``bias`` parameter. If set to ``None``, follows the default
+            initialization of the PyTorch builtin ``torch.nn.Embedding`` layer.
+
+    Attributes:
+        weight (Tensor): the learnable weights of the module of shape
+            (num_embeddings, embedding_dim) initialized from
+            :math:`\mathcal{N}(0, 1)`
+
+    Shape:
+        - Input: :math:`(*)`, IntTensor or LongTensor of arbitrary shape
+            containing the indices to extract
+        - Output: :math:`(*, H)`, where `*` is the input shape and
+            :math:`H=\text{embedding\_dim}`
+
+    .. note::
+        Keep in mind that only a limited number of optimizers support
+        sparse gradients: currently it's :class:`optim.SGD` (`CUDA` and `CPU`),
+        :class:`optim.SparseAdam` (`CUDA` and `CPU`) and :class:`optim.Adagrad`
+        (`CPU`)
+
+    .. note::
+        The default initialization of the ``weight`` parameter is different in
+        PyTorch and fairscale: The former uses ``torch.nn.init.normal_`` while
+        the latter uses `torch.nn.init.xavier_normal_``. We follow the PyTorch
+        default behavior.
+    """
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        padding_idx: Optional[int] = None,
+        scale_grad_by_freq: bool = False,
+        sparse: bool = False,
+        init_fn: Optional[Callable[[torch.Tensor], Any]] = None,
+    ) -> None:
+        super().__init__()
+        self.num_emeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        self.padding_idx = padding_idx
+        self.scale_grad_by_freq = scale_grad_by_freq
+        self.sparse = sparse
+        self.init_fn = init_fn
+
+        tp_world_size = get_model_parallel_world_size()
+        assert self.embdding_dim % tp_world_size == 0, (
+            "ParallelEmbedding currently requires that the embedding "
+            "dimension is evenly divisible by the tensor parallel world size."
+        )
+        self.local_embeddding_dim = embedding_dim // tp_world_size
+
+        self.weight = nn.Parameter(
+            torch.empty([num_embeddings, self.local_embeddding_dim])
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        init_fn = self.init_fn or nn.init.normal_
+        init_tensor_parallel_weights(self.weight, init_fn, 1)
+        self._fill_padding_idx_with_zero()
+
+    def _fill_padding_idx_with_zero(self) -> None:
+        if self.padding_idx is not None:
+            with torch.no_grad():
+                self.weight[self.padding_idx].fill_(0)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        input_parallel = copy_to_model_parallel_region(input_)
+        output_parallel = F.embedding(
+            input_parallel,
+            self.weight,
+            self.padding_idx,
+            None, 2.0,  # max_norm and norm_type, non-trivial to impl for tp.
+            self.scale_grad_by_freq,
+            self.sparse,
+        )
+        output = gather_from_model_parallel_region(output_parallel)
+        return output
+
+    def extra_repr(self) -> str:
+        s = "{num_embeddings}, {embedding_dim}"
+        if self.padding_idx is not None:
+            s += ", padding_idx={padding_idx}"
+        if self.scale_grad_by_freq is not False:
+            s += ', scale_grad_by_freq={scale_grad_by_freq}'
+        if self.sparse is not False:
+            s += ', sparse=True'
+        return s.format(**self.__dict__)

--- a/accessory/model/layers/tensor_parallel/linear.py
+++ b/accessory/model/layers/tensor_parallel/linear.py
@@ -1,0 +1,207 @@
+from typing import Any, Callable, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from fairscale.nn.model_parallel.initialize import (
+    get_model_parallel_world_size
+)
+from fairscale.nn.model_parallel.mappings import (
+    copy_to_model_parallel_region,
+    gather_from_model_parallel_region,
+    scatter_to_model_parallel_region,
+    reduce_from_model_parallel_region,
+)
+
+from ..linear import (
+    get_default_linear_weight_init_fn,
+    get_default_linear_bias_init_fn,
+)
+from .utils import init_tensor_parallel_weights
+
+
+class ColumnParallelLinear(nn.Module):
+    r"""Linear layer with column-wise tensor parallelism. A column parallel
+    linear layer expects that the input tensor is replicated among tensor
+    parallel ranks, and each rank calculate a part of the output dimensions.
+
+    Args:
+        in_features (int): Input feature dimension.
+        out_features (int): Output feaature dimension.
+        bias (bool): Whether a learnable bias is added. Default is ``False``.
+        weight_init_fn (Callable[[torch.Tensor], Any], optional): Initializer
+            function of the ``weight`` parameter. If not set, follows the
+            default initialization of the builtin ``nn.Linear``. The given
+            function should assume that the input tensor is unsharded and the
+            distribution of the tensor is taken care of by the outside logic.
+        bias_init_fn (Callable[[torch.Tensor], Any], optional): Initializer
+            function of the ``bias`` parameter. If not set, follows the default
+            initialization of the builtin ``nn.Linear``. The given function
+            should assume that the input tensor is unsharded and the
+            distribution of the tensor is taken care of by the outside logic.
+        gather_output (bool): Whether output should be all-gathered after being
+            calculated separately on each rank. Default is ``True``.
+
+    .. note::
+        The default initialization of the ``bias`` parameter is different in
+        PyTorch and fairscale: The former uses a uniform distribution while the
+        latter uses an all-zero constant initialization. We follow the official
+        PyTorch behavior. To use the fairscale behavior, pass
+        ``torch.nn.init.zeros_`` as the ``bias_init_fn`` argument.
+    """
+
+    def __init__(
+        self, in_features: int, out_features: int, bias: bool = True,
+        weight_init_fn: Optional[Callable[[torch.Tensor], Any]] = None,
+        bias_init_fn: Optional[Callable[[torch.Tensor], Any]] = None,
+        gather_output: bool = True,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight_init_fn = weight_init_fn
+        self.bias_init_fn = bias_init_fn
+        self.gather_output = gather_output
+
+        tp_world_size = get_model_parallel_world_size()
+        assert self.out_features % tp_world_size == 0, (
+            "ColumnParallelLinear currently requires that the output "
+            "dimension is evenly divisible by the tensor parallel world size."
+        )
+        self.local_out_features = self.out_features // tp_world_size
+
+        self.weight = nn.Parameter(
+            torch.empty([self.local_out_features, in_features])
+        )
+        if bias:
+            self.bias = nn.Parameter(torch.empty([self.local_out_features]))
+        else:
+            self.register_parameter("bias", None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        weight_init_fn = (
+            self.weight_init_fn or get_default_linear_weight_init_fn()
+        )
+        init_tensor_parallel_weights(self.weight, weight_init_fn, 0)
+        if self.bias is not None:
+            bias_init_fn = (
+                self.bias_init_fn
+                or get_default_linear_bias_init_fn(self.in_features)
+            )
+            init_tensor_parallel_weights(self.bias, bias_init_fn, 0)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        input_parallel = copy_to_model_parallel_region(input_)
+        output_parallel = F.linear(input_parallel, self.weight, self.bias)
+        if self.gather_output:
+            output = gather_from_model_parallel_region(output_parallel)
+            return output
+        else:
+            return output_parallel
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, "
+            f"out_features={self.out_features}, "
+            f"local_out_features={self.local_out_features}, "
+            f"bias={self.bias is not None}, "
+            f"gather_output={self.gather_output}"
+        )
+
+
+class RowParallelLinear(nn.Module):
+    r"""Linear layer with row-wise tensor parallelism. A row parallel linear
+    layer divides the input feature dimensions among the tensor parallel ranks,
+    calculates the linear mapping on each part of the dimensions and sum the
+    results to form the output.
+
+    Args:
+        in_features (int): Input feature dimension.
+        out_features (int): Output feaature dimension.
+        bias (bool): Whether a learnable bias is added. Default is ``False``.
+        weight_init_fn (Callable[[torch.Tensor], Any], optional): Initializer
+            function of the ``weight`` parameter. If not set, follows the
+            default initialization of the builtin ``nn.Linear``. The given
+            function should assume that the input tensor is unsharded and the
+            distribution of the tensor is taken care of by the outside logic.
+        bias_init_fn (Callable[[torch.Tensor], Any], optional): Initializer
+            function of the ``bias`` parameter. If not set, follows the default
+            initialization of the builtin ``nn.Linear``. The given function
+            should assume that the input tensor is unsharded and the
+            distribution of the tensor is taken care of by the outside logic.
+        input_is_parallel (bool): If true, assumes that the input tensor is
+            already sharded (e.g., the output of a ColumnParallelLinear in
+            which ``gather_output=False``).
+
+    .. note::
+        The default initialization of the ``bias`` parameter is different in
+        PyTorch and fairscale: The former uses a uniform distribution while the
+        latter uses an all-zero constant initialization. We follow the official
+        PyTorch behavior. To use the fairscale behavior, pass
+        ``torch.nn.init.zeros_`` as the ``bias_init_fn`` argument.
+    """
+
+    def __init__(
+        self, in_features: int, out_features: int, bias: bool = True,
+        weight_init_fn: Optional[Callable[[torch.Tensor], Any]] = None,
+        bias_init_fn: Optional[Callable[[torch.Tensor], Any]] = None,
+        input_is_parallel: bool = False,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight_init_fn = weight_init_fn
+        self.bias_init_fn = bias_init_fn
+        self.input_is_parallel = input_is_parallel
+
+        tp_world_size = get_model_parallel_world_size()
+        assert self.in_features % tp_world_size == 0, (
+            "RowParallelLinear currently requires that the output dimension"
+            "is evenly divisible by the tensor parallel world size."
+        )
+        self.local_in_features = in_features
+
+        self.weight = nn.Parameter(
+            torch.empty([self.out_features, self.local_in_features])
+        )
+        if bias:
+            self.bias = nn.Parameter(torch.empty([self.out_features]))
+        else:
+            self.register_parameter("bias", None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        weight_init_fn = (
+            self.weight_init_fn or get_default_linear_weight_init_fn()
+        )
+        init_tensor_parallel_weights(self.weight, weight_init_fn, 1)
+        if self.bias is not None:
+            bias_init_fn = (
+                self.bias_init_fn
+                or get_default_linear_bias_init_fn(self.in_features)
+            )
+            init_tensor_parallel_weights(self.bias, bias_init_fn, -1)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        input_parallel = (
+            input_ if self.input_is_parallel else
+            scatter_to_model_parallel_region(input_)
+        )
+        output_parallel = F.linear(input_parallel, self.weight)
+        output = reduce_from_model_parallel_region(output_parallel)
+        if self.bias is not None:
+            output = output + self.bias
+        return output
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, "
+            f"local_in_features={self.local_in_features}, "
+            f"out_features={self.out_features}, "
+            f"bias={self.bias is not None}, "
+            f"input_is_parallel={self.input_is_parallel}"
+        )

--- a/accessory/model/layers/tensor_parallel/utils.py
+++ b/accessory/model/layers/tensor_parallel/utils.py
@@ -1,0 +1,81 @@
+from typing import Any, Callable
+
+import torch
+import torch.distributed as dist
+
+from fairscale.nn.model_parallel.initialize import (
+    get_model_parallel_group,
+    get_model_parallel_src_rank,
+    get_model_parallel_rank,
+    get_model_parallel_world_size,
+)
+
+
+def _broadcast_replicated_tensor(tensor: torch.Tensor) -> None:
+    group = get_model_parallel_group()
+    backend = dist.get_backend(group)
+    reduction_device = "cuda" if backend == "nccl" else tensor.device
+
+    bcast_tensor = tensor.to(reduction_device)
+    dist.broadcast(bcast_tensor, get_model_parallel_src_rank(), group)
+    if bcast_tensor is not tensor:
+        tensor.copy_(bcast_tensor)
+
+
+def _scatter_distributed_tensor(
+    tensor: torch.Tensor, master_tensor: torch.Tensor, shard_dim: int
+) -> None:
+    group = get_model_parallel_group()
+    backend = dist.get_backend(group)
+    reduction_device = "cuda" if backend == "nccl" else tensor.device
+
+    if get_model_parallel_rank() == 0:
+        master_tensor = master_tensor.to(reduction_device)
+        recv_tensor = tensor.to(reduction_device)
+        dist.scatter(recv_tensor, master_tensor.split(tensor.size(shard_dim)),
+                     get_model_parallel_src_rank(), group)
+    else:
+        recv_tensor = tensor.to(reduction_device)
+        dist.scatter(recv_tensor, None, get_model_parallel_src_rank(), group)
+    if recv_tensor is not tensor:
+        tensor.copy_(recv_tensor)
+
+
+def init_tensor_parallel_weights(
+    tensor: torch.Tensor, init_fn: Callable[[torch.Tensor], Any],
+    shard_dim: int = -1
+) -> None:
+    r"""This is a helper function that initializes a tensor-parallel tensor
+    from a regular tensor-parallel-unaware ``init_fn``. A typical use case is
+    that ``init_fn`` may calculate the initialization statistics based on the
+    ``fan_in`` or ``fan_out`` measured with the shape of the tensor which
+    will be incorrect if the tensor is sharded across tensor-parallel ranks.
+    Thus, we create a helper function that initializes a tensor as a whole and
+    then distribute it across the model parallel ranks.
+
+    Args:
+        tensor (torch.Tensor): The (tensor-parallel-sharded) tensor to
+            initialize.
+        init_fn (Callable[[torch.Tensor], Any]): The tensor-parallel-unaware
+            initializer to be called on the unsharded weights.
+        shard_dim (int): The sharding dimension of the tensor. If < 0, the
+            tensor is treated as replicated. Default is -1.
+    """
+    if tensor.is_meta:
+        return
+
+    if shard_dim < 0:
+        if get_model_parallel_rank() == 0:
+            init_fn(tensor.data)
+        _broadcast_replicated_tensor(tensor.data)
+        return
+
+    if get_model_parallel_rank() == 0:
+        master_tensor_shape = list(tensor.size())
+        master_tensor_shape[shard_dim] *= get_model_parallel_world_size()
+        master_tensor = torch.empty(master_tensor_shape,
+                                    device=tensor.device, dtype=tensor.dtype)
+    else:
+        master_tensor = None
+    init_fn(master_tensor)
+    _scatter_distributed_tensor(tensor.data, master_tensor, shard_dim)


### PR DESCRIPTION
This PR aims to add the support of lazy model initialization. This is one of the two steps to lower the CPU memory usage for quantized models. Quantization is currently implemented by replacing regular linear layers with quantized linear layers. Without lazy init, the full-precision model before replacement results in a huge peak memory usage, making both training and inference hard to run on commodity hardware even with aggressive quantization: For example, the 4-bit 13B, which theoretically only needs 6.5GB of memory and fits comfortably in any mainstream PC, now requires 52GB of memory (full precision model and full precision checkpoint); and the 4-bit 70B model, which theoretically needs 35GB of memory and fits in two 3090s, now requires 280GB of memory which is only possible on some expensive HEDT and server platforms.

With lazy init, the model creation steps become: (1) create a placeholder model without allocating any actual storage, (2) replace layers with quantized ones and (3) instantiate all tensors. In this way, we need not manually re-implement a quantized version for each (current or future) model, and only the amount of storage after quantization is actually allocated.

However, supporting lazy init turns out to be a complicated task, as PyTorch essentially provides no good way to decouple model creation and weight initialization at this moment. Despite that tensors can be created as meta, there seems to be no reliable way to initialize them afterwards: The fairscale layers tend to initialize the weights in __init__ and simply do not provide a separate method to initialize the weights after creation; and even if most PyTorch built-in layers do provide a reset_parameter methods as of v2.0.1, they usually do not support custom initialization (e.g., LoRA needs zero init, but ``torch.nn.Linear.reset_parameters`` always initializes the weights randomly following a uniform distribution).

Facing such a dilemma, I am trying to follow the lazy init implementation of PyTorch FSDP: Relying on the module's ``reset_parameter`` method for each module containing directly managed parameters and buffers, with the heavy lifting left to implementing the ``reset_parameter`` for each module we used but do not have a working one in all cases.

The model creation process is supposed to be like the following after the change:

```Python
# All weights on meta device, including quantized layers but except vision encoder.
with default_tensor_type(..., meta=True):
    model = MetaModel(...)

# All tensors in checkpoints are materialized. If a quantized layer sees full-precision states, quantize before materialize.
utils.tensor_parallel.load_tensor_parallel_model_list(...)

# Materialize remaining weights (unseen in loaded checkpoints, using the reset_parameter method).
model.materialize()
```

Following this plan, the proposed code change is roughly organized into the following parts:

- [ ] Equipping each layer with a correct and flexible ``reset_parameter`` method.
- [ ] Extend the context manager ``default_tensor_type`` to support meta tensor creation. Disable meta tensor creation around visual backbones (for loading their weights; it may be problematic for large vision models for which we may discuss later).
- [ ] Quantization layers support meta creation and quantized materialization (i.e., from full-precision weights).
- [ ] Materialization logic of full-precision tensors (materialize firstly from checkpoints, and if not found in any checkpoint, use ``reset_parameters``).
- [ ] Change the defined models to use the layers with ``reset_parameters`` implemented; change the training / inference entry scripts to use the new model creation logic.

This PR is going to involve an extensive code refactor and need thorough testings so mark it as draft for now.