### PR TITLE
Fix SPHINX inference memory with image input

### DIFF
--- a/accessory/model/LLM/llama_ens.py
+++ b/accessory/model/LLM/llama_ens.py
@@ -482,7 +482,13 @@ class Transformer(nn.Module):
             h_bos, h_caption = h[:, :1], h[:, 1:]
             image_tokens = self.encode_image(image)
             self.cache_image_words = image_tokens.shape[1] + 1 + 1
-            h = torch.cat((h_bos, self.start_img.repeat(_bsz, 1, 1), image_tokens, self.end_img.repeat(_bsz, 1, 1), h_caption), dim=1)
+            h = torch.cat((
+                h_bos,
+                self.start_img.repeat(_bsz, 1, 1),
+                image_tokens,
+                self.end_img.repeat(_bsz, 1, 1),
+                h_caption,
+            ), dim=1).to(h_bos)
             seqlen = h.shape[1]
             freqs_cis = self.freqs_cis[0: seqlen]
         else:

--- a/accessory/model/LLM/llama_ens10.py
+++ b/accessory/model/LLM/llama_ens10.py
@@ -478,7 +478,7 @@ class Transformer(nn.Module):
             image_tokens = torch.cat(l_image_tokens, dim=1)
             image_words = image_tokens.shape[1]
             assert image_words == self.image_words, f"{image_words} v.s. {self.image_words}, {[_.shape for _ in l_image_tokens]}"
-            h = torch.cat((h_bos, image_tokens, h_caption), dim=1)
+            h = torch.cat((h_bos, image_tokens, h_caption), dim=1).to(h_bos)
             seqlen = h.shape[1]
 
         freqs_cis = self.freqs_cis[:seqlen]

--- a/accessory/model/LLM/llama_ens5.py
+++ b/accessory/model/LLM/llama_ens5.py
@@ -506,7 +506,7 @@ class Transformer(nn.Module):
             image_tokens = torch.cat(l_image_tokens, dim=1)
             self.cache_image_words = image_tokens.shape[1]
             assert self.cache_image_words == self.image_words
-            h = torch.cat((h_bos, image_tokens, h_caption), dim=1)
+            h = torch.cat((h_bos, image_tokens, h_caption), dim=1).to(h_bos)
             seqlen = h.shape[1]
             freqs_cis = self.freqs_cis[0: seqlen]
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas
 tensorboard
 fairscale
 sentencepiece
-gradio
+gradio==3.50.2
 open_clip_torch
 fire
 packaging


### PR DESCRIPTION
In the previous implementation, the ``encode_image`` methods of the SPHINX series models return FP32 features. This promotes the concatenated (image+text) embeddings to FP32 and leads to a few GBs of memory overhead, which in turn makes the 4-bit quantized SPHINX OOM on 24GB GPUs.

With the dtype explicitly casted back the models now run fine on 24GB GPUs (NF4 quantized) at the longest sequence length (4k)

![image](https://github.com/Alpha-VLLM/LLaMA2-Accessory/assets/53928811/39328aba-9270-4b9a-9a54-319013392134)

Also pinning gradio to 3.x for now as gradio 4.x seem to introduce compatibility issues. Will bump the version in the future after some testings.


